### PR TITLE
BeSimple\SoapClient\WsdlDownloader deprecated curly braces

### DIFF
--- a/src/BeSimple/SoapClient/WsdlDownloader.php
+++ b/src/BeSimple/SoapClient/WsdlDownloader.php
@@ -214,7 +214,7 @@ class WsdlDownloader
         $urlParts = parse_url($base);
 
         // combine base path with relative path
-        if (isset($urlParts['path']) && '/' === $relative{0}) {
+        if (isset($urlParts['path']) && '/' === $relative[0]) {
             // $relative is absolute path from domain (starts with /)
             $path = $relative;
         } elseif (isset($urlParts['path']) && strrpos($urlParts['path'], '/') === (strlen($urlParts['path']) )) {


### PR DESCRIPTION
Line 217 in the WsdlDownloader class has curly braces to access a string offset. This was deprecated (https://wiki.php.net/rfc/deprecate_curly_braces_array_access). This PR changes the curly braces to [].